### PR TITLE
fix #6: overridden methods won't be included twice

### DIFF
--- a/MixinRefactoring.Test/Integration/Dummys/Person.cs
+++ b/MixinRefactoring.Test/Integration/Dummys/Person.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace MixinRefactoring.Test
 {
@@ -268,11 +269,31 @@ namespace MixinRefactoring.Test
     }
 
     /// <summary>
+    /// class that already overrides a method from base.
+    /// The mixins method with the same signature should not be implemented again
+    /// </summary>
+    public class PersonWithOverriddenMethod : PersonWithAbstractWork
+    {
+        private Worker _worker;
+        public override void Work() { }
+    }
+
+    /// <summary>
     /// class with an abstract property
     /// </summary>
     public abstract class PersonWithAbstractName
     {
         public abstract string Name { get; set; }
+    }
+
+    /// <summary>
+    /// class that overrides a property from base with same
+    /// signature as mixin property
+    /// </summary>
+    public class PersonWithOverriddenProperty : PersonWithAbstractName
+    {
+        private SimpleName _name;
+        public override string Name { get; set; }
     }
 
     /// <summary>

--- a/MixinRefactoring.Test/Integration/IncludeMixinSyntaxWriterTest.cs
+++ b/MixinRefactoring.Test/Integration/IncludeMixinSyntaxWriterTest.cs
@@ -117,5 +117,7 @@ namespace MixinRefactoring.Test
                 .ToString();
             Assert.IsTrue(propertyDeclaration.Contains("override"));
         }
+
+        
     }
 }

--- a/MixinRefactoring.Test/Integration/MixinWithPropertyTest.cs
+++ b/MixinRefactoring.Test/Integration/MixinWithPropertyTest.cs
@@ -258,10 +258,30 @@ namespace MixinRefactoring.Test
             // only one method from the mixin should be implemented, the other one
             // is alredy implemented by childs base
             Assert.AreEqual(1, mixer.PropertiesToImplement.Count(x => x.Name == "Name"));
-            Assert.IsTrue(mixer.PropertiesToImplement.Single().NeedsOverrideKeyword);
+            Assert.IsTrue(mixer.PropertiesToImplement.Single().IsOverride);
         }
 
+        /// <summary>
+        /// check that issue
+        /// https://github.com/pgenfer/mixinSharp/issues/6
+        /// is also fixed for properties
+        /// </summary>
+        [Test]
+        public void ChildWithOverrideProperty_Include_PropertyOverrideNotCreated()
+        {
+            var sourceCode = new SourceCode("Person.cs", "Name.cs");
+            var personClass = sourceCode.Class("PersonWithOverriddenProperty");
+            var mixinReference = personClass.FindMixinReference("_name");
+            var semanticModel = sourceCode.Semantic;
 
-        // TODO: skip basic data types (like string, int etc...)
+            var mixin = new MixinReferenceFactory(semanticModel).Create(mixinReference);
+            var child = new ClassFactory(semanticModel).Create(personClass);
+
+            var mixer = new Mixer();
+            mixer.IncludeMixinInChild(mixin, child);
+
+            // no property to override because child overrides it already
+            Assert.AreEqual(0, mixer.PropertiesToImplement.Count());
+        }
     }
 }

--- a/MixinRefactoring.Test/Unit/MemberCompareTest.cs
+++ b/MixinRefactoring.Test/Unit/MemberCompareTest.cs
@@ -21,7 +21,7 @@ namespace MixinRefactoring.Test
             var otherProperty = new Property("p2", type, true, true);
             var comparer = new MemberComparer();
             // Act
-            var equal = comparer.IsImplementationOf(property, otherProperty);
+            var equal = comparer.IsSameAs(property, otherProperty);
             // Assert
             Assert.IsFalse(equal);
         }
@@ -39,7 +39,7 @@ namespace MixinRefactoring.Test
             var comparer = new MemberComparer();
 
             // Act
-            var equal = comparer.IsImplementationOf(property, otherProperty);
+            var equal = comparer.IsSameAs(property, otherProperty);
 
             // First ensure that both types are different
             Assert.AreNotEqual(typeOfProperty, typeOfOtherProperty);
@@ -58,7 +58,7 @@ namespace MixinRefactoring.Test
             var otherProperty = new Property("p1", type, true, false);
             var comparer = new MemberComparer();
             // Act
-            var equal = comparer.IsImplementationOf(property, otherProperty);
+            var equal = comparer.IsSameAs(property, otherProperty);
             // Assert
             Assert.IsTrue(equal);
         }

--- a/MixinRefactoring/IncludeMixinSyntaxWriter.cs
+++ b/MixinRefactoring/IncludeMixinSyntaxWriter.cs
@@ -144,7 +144,7 @@ namespace MixinRefactoring
         protected SyntaxTokenList CreateModifiers(Method method)
         {
             var modifiers = TokenList(Token(SyntaxKind.PublicKeyword));
-            modifiers = method.IsOverrideFromObject || method.NeedsOverrideKeyword ?
+            modifiers = method.IsOverrideFromObject || method.IsOverride ?
                 modifiers.Add(Token(SyntaxKind.OverrideKeyword)) :
                 modifiers;
             return modifiers;
@@ -153,7 +153,7 @@ namespace MixinRefactoring
         protected SyntaxTokenList CreateModifiers(Member member)
         {
             var modifiers = TokenList(Token(SyntaxKind.PublicKeyword));
-            modifiers = member.NeedsOverrideKeyword ?
+            modifiers = member.IsOverride ?
                 modifiers.Add(Token(SyntaxKind.OverrideKeyword)) :
                 modifiers;
             return modifiers;

--- a/MixinRefactoring/MemberComparer.cs
+++ b/MixinRefactoring/MemberComparer.cs
@@ -2,7 +2,7 @@
 {
     public class MemberComparer
     {
-        public virtual bool IsImplementationOf(Member first, Member second)
+        public virtual bool IsSameAs(Member first, Member second)
         {
             return IsEqual((dynamic)first, (dynamic)second);
         }

--- a/MixinRefactoring/MetaData/Class.cs
+++ b/MixinRefactoring/MetaData/Class.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace MixinRefactoring
 {
@@ -12,8 +13,16 @@ namespace MixinRefactoring
         private PropertyList _properties = new PropertyList();
         private MethodList _methods = new MethodList();
         private readonly NameMixin _name = new NameMixin();
-        public void AddProperty(Property newProperty) => _properties.AddProperty(newProperty);
-        public void AddMethod(Method newMethod) => _methods.AddMethod(newMethod);
+        public void AddProperty(Property newProperty)
+        {
+            _properties.AddProperty(newProperty);
+            newProperty.Class = this;
+        }
+        public void AddMethod(Method newMethod)
+        {
+            _methods.AddMethod(newMethod);
+            newMethod.Class = this;
+        }
         public IEnumerable<Property> Properties => _properties;
         public IEnumerable<Method> Methods => _methods;
         public string Name
@@ -47,6 +56,20 @@ namespace MixinRefactoring
                     members.AddRange(BaseClass.MembersFromThisAndBase);
                 return members;
             }
+        }
+
+        public bool HasOverride(Member abstractMember)
+        {
+            if (!abstractMember.IsAbstract)
+                return false;
+            var memberComparer = new MemberComparer();
+            // check if we have a member with the same signature
+            // but with the override keyword
+            var sameMembers = MembersFromThisAndBase
+                .Where(x => x.IsOverride)
+                .Where(x => !x.IsAbstract)
+                .Where(x => memberComparer.IsSameAs(x, abstractMember));
+            return sameMembers.Any();
         }
     }
 }

--- a/MixinRefactoring/MetaData/Member.cs
+++ b/MixinRefactoring/MetaData/Member.cs
@@ -10,6 +10,13 @@ namespace MixinRefactoring
     {
         private NameMixin _name = new NameMixin();
 
+        /// <summary>
+        /// the class where this member is declared.
+        /// This information is needed so that we know
+        /// if the member is declared in a base class or in the class itself
+        /// </summary>
+        public Class Class { get; set; }
+        
         public string Name
         {
             get
@@ -23,6 +30,11 @@ namespace MixinRefactoring
             }
         }
 
+        /// <summary>
+        /// returns the modifiers as a string for easier usage of to string method
+        /// </summary>
+        protected string Modifiers => IsOverride ? "override" : IsAbstract ? "abstract" : string.Empty;
+
         public override string ToString() => _name.ToString();
 
         /// <summary>
@@ -30,10 +42,9 @@ namespace MixinRefactoring
         /// </summary>
         public bool IsAbstract { get; set; }
         /// <summary>
-        /// when generating the method, an override keyword
-        /// is necessary
+        /// This member has the override keyword set
         /// </summary>
-        public bool NeedsOverrideKeyword { get; private set; }
+        public bool IsOverride { get; set; }
         /// <summary>
         /// creates a copy of the given instance, 
         /// should be implemented by derived classes
@@ -50,10 +61,10 @@ namespace MixinRefactoring
         {
             var copy = CreateCopy();
             copy.Name = Name;
-            copy.NeedsOverrideKeyword = needsOverrideKeywork;
+            copy.IsOverride = needsOverrideKeywork;
             // if this members will have an override keyword, it cannot be abstract
             copy.IsAbstract = needsOverrideKeywork ? false : IsAbstract;
             return copy;
-        }
+        }      
     }
 }

--- a/MixinRefactoring/MetaData/Method.cs
+++ b/MixinRefactoring/MetaData/Method.cs
@@ -32,7 +32,7 @@ namespace MixinRefactoring
         public void Add(Parameter parameter) => _parameters.Add(parameter);
       
         public int ParameterCount => _parameters.ParameterCount;
-        public override string ToString() => $"{ReturnType.ToString()} {Name.ToString()}({_parameters.ToString()})";
+        public override string ToString() => $"{Modifiers} {ReturnType.ToString()} {Name.ToString()}({_parameters.ToString()})".Trim(); // remove leading spaces when no modifiers
         public Parameter GetParameter(int index) => _parameters.GetParameter(index);
 
         protected override Member CreateCopy()

--- a/MixinRefactoring/SemanticReader/MethodSymbolReader.cs
+++ b/MixinRefactoring/SemanticReader/MethodSymbolReader.cs
@@ -35,6 +35,7 @@ namespace MixinRefactoring
                     methodSymbol.ReturnType, 
                     isOverrideFromObject);
                 method.IsAbstract = methodSymbol.IsAbstract;
+                method.IsOverride = methodSymbol.IsOverride;
                 var parameterReader = new ParameterSymbolReader(method);
                 parameterReader.VisitSymbol(methodSymbol);
                 _methods.AddMethod(method);

--- a/MixinRefactoring/SemanticReader/PropertySymbolReader.cs
+++ b/MixinRefactoring/SemanticReader/PropertySymbolReader.cs
@@ -42,7 +42,8 @@ namespace MixinRefactoring
                     propertySymbol.GetMethod != null,
                     propertySymbol.SetMethod != null);
             }
-            property.IsAbstract = propertySymbol.IsAbstract;             
+            property.IsAbstract = propertySymbol.IsAbstract;
+            property.IsOverride = propertySymbol.IsOverride;          
             _properties.AddProperty(property);
         }
     }

--- a/MixinRefactoring/SyntaxReader/MethodSyntaxReader.cs
+++ b/MixinRefactoring/SyntaxReader/MethodSyntaxReader.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace MixinRefactoring
 {
@@ -23,6 +24,10 @@ namespace MixinRefactoring
             var method = new Method(
                 node.Identifier.ToString(),
                 (ITypeSymbol)_semantic.GetSymbolInfo(node.ReturnType).Symbol);
+            // set correct modifiers
+            method.IsOverride = node.Modifiers.Any(x => x.IsKind(SyntaxKind.OverrideKeyword));
+            method.IsAbstract = node.Modifiers.Any(x => x.IsKind(SyntaxKind.AbstractKeyword));
+            // read parameters
             var parameterSyntaxReader = new ParameterSyntaxReader(method, _semantic);
             parameterSyntaxReader.Visit(node);
             _methods.AddMethod(method);

--- a/MixinRefactoring/SyntaxReader/PropertySyntaxReader.cs
+++ b/MixinRefactoring/SyntaxReader/PropertySyntaxReader.cs
@@ -38,6 +38,11 @@ namespace MixinRefactoring
                 node.Identifier.ToString(),
                 (ITypeSymbol)_semantic.GetSymbolInfo(node.Type).Symbol,
                 hasGetter, hasSetter);
+
+            // set correct modifiers
+            property.IsOverride = node.Modifiers.Any(x => x.IsKind(SyntaxKind.OverrideKeyword));
+            property.IsAbstract = node.Modifiers.Any(x => x.IsKind(SyntaxKind.AbstractKeyword));
+
             _properties.AddProperty(property);            
         }
     }    


### PR DESCRIPTION
If a bases abstract method is already overridden in the child class, a
mixins method with the same signature won't be added additionally.