### PR TITLE
[update] broaden .vsix install targets to include VS 15

### DIFF
--- a/MixinRefactoring.Vsix/source.extension.vsixmanifest
+++ b/MixinRefactoring.Vsix/source.extension.vsixmanifest
@@ -12,9 +12,9 @@
     <Tags>C#, Mixin, Composition, Delegation</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Visual Studio 15, which will probably end up being VS 2016, is currently in preview 2. It is surprisingly stable and contains many useful features. This PR broadens the Install Targets of the Vsix project to enable discovering and installing _mixinSharp_.
